### PR TITLE
integration with bap

### DIFF
--- a/bap_build.sh
+++ b/bap_build.sh
@@ -15,6 +15,7 @@ export OPAMVERBOSE=1
 export OPAMJOBS=4
 
 echo 'yes' | sudo add-apt-repository ppa:$ppa
+echo 'yes' | sudo apt-add-repository ppa:chris-lea/zeromq
 sudo apt-get update -qq
 sudo apt-get install -qq ocaml ocaml-native-compilers camlp4-extra opam $SYS_DEPENDS
 

--- a/bap_build.sh
+++ b/bap_build.sh
@@ -7,8 +7,8 @@ git clone --depth=1 --branch $BAP_TAG $BAP_URL
 
 pushd bap
 
-SYS_DEPENDS=`cat apt.deps`
-OPAM_DEPENDS=`cat opam.deps`
+OPAM_DEPENDS=`cat opam.deps opam.opt.deps`
+SYS_DEPENDS=`cat apt.deps apt.opt.deps`
 ppa=avsm/ocaml42+opam12
 export OPAMYES=1
 export OPAMVERBOSE=1

--- a/bap_build.sh
+++ b/bap_build.sh
@@ -9,6 +9,7 @@ pushd bap
 
 SYS_DEPENDS=`cat apt.deps`
 OPAM_DEPENDS=`cat opam.deps`
+ppa=avsm/ocaml42+opam12
 export OPAMYES=1
 export OPAMVERBOSE=1
 export OPAMJOBS=4

--- a/bap_build.sh
+++ b/bap_build.sh
@@ -1,116 +1,27 @@
 #!/bin/bash -e
 
-# this script is woefully incomplete
-# because I already had tons of stuff on this VM
-# update before release
+BAP_URL="https://github.com/ivg/bap"
+BAP_TAG="bap+qira"
 
-pushd .
-cd /tmp
-wget https://bootstrap.pypa.io/get-pip.py
-sudo python get-pip.py
-popd
+git clone --depth=1 --branch $BAP_TAG $BAP_URL
 
-sudo apt-get install libgmp-dev m4 ocaml-interp libpqxx-3.1 libpqxx3-dev glogg python-dev postgresql-server-dev-9.3 g++-4.8 gcc-4.8 ocaml-findlib opam camlp4-extra cmake
+pushd bap
+
+SYS_DEPENDS=`cat apt.deps`
+OPAM_DEPENDS=`cat opam.deps`
+export OPAMYES=1
+export OPAMVERBOSE=1
+export OPAMJOBS=4
+
+echo 'yes' | sudo add-apt-repository ppa:$ppa
+sudo apt-get update -qq
+sudo apt-get install -qq ocaml ocaml-native-compilers camlp4-extra opam $SYS_DEPENDS
+
 opam init
-opam install piqi zarith core_kernel
-
-mkdir -p bap
-cd bap
-
-if [ ! -d capnproto ]; then
-  pushd .
-  git clone https://github.com/kentonv/capnproto.git
-  cd capnproto/c++
-  ./setup-autotools.sh
-  autoreconf -i && ./configure && make -j6 check && sudo make install
-  popd
-fi
-
-sudo pip install -U cython
-sudo pip install pycapnp
-
-if [ ! -d bap-types ]; then
-  pushd .
-  git clone https://github.com/BinaryAnalysisPlatform/bap-types.git
-
-  cd bap-types
-  ./configure
-  make -j $(grep processor < /proc/cpuinfo | wc -l)
-  make install
-
-  popd
-fi
-
-if [ ! -d llvm ]; then
-  pushd .
-  #wget http://ftp.de.debian.org/debian/pool/main/l/llvm-toolchain-snapshot/llvm-toolchain-snapshot_3.6~svn215195.orig.tar.bz2
-  #tar xvf llvm-toolchain-snapshot_3.6~svn215195.orig.tar.bz2
-  #mv llvm-toolchain-snapshot_3.6~svn215195 llvm
-  #cd llvm
-  git clone https://github.com/llvm-mirror/llvm.git
-  cd llvm
-  git checkout 0914f63cc3ce62b6872e2760dd325829b52d8396
-  patch -f -p1 < ../../extra/llvmpatch/c-disasm-mcinst
-  popd
-fi
-
-if [ ! -d llvm-build ]; then
-  pushd .
-  mkdir llvm-build
-  cd llvm-build
-  ../llvm/configure --enable-optimized --disable-assertions
-  make -j $(grep processor < /proc/cpuinfo | wc -l)
-
-  # clobber the system llvm
-  sudo make install
-  popd
-fi
-
-if [ ! -d llvm-mc ]; then
-  pushd .
-  git clone https://github.com/BinaryAnalysisPlatform/llvm-mc.git
-  cd llvm-mc
-
-  ./configure
-  make -j $(grep processor < /proc/cpuinfo | wc -l)
-  make install
-  popd
-fi
-
-if [ ! -d bap-lifter ]; then
-  pushd .
-  git clone https://github.com/BinaryAnalysisPlatform/bap-lifter.git
-
-  cd bap-lifter
-  ./configure
-  make -j $(grep processor < /proc/cpuinfo | wc -l)
-  make install
-
-  popd
-fi
-
-# below this line is broken
-
-if [ ! -d holmes ]; then
-  pushd .
-  git clone https://github.com/BinaryAnalysisPlatform/holmes.git
-
-  cd holmes
-  mkdir build && cd build
-  cmake -DCMAKE_CXX_COMPILER=g++-4.8 ..
-  make
-
-  popd
-fi
-
-if [ ! -d bap-container ]; then
-  git clone https://github.com/BinaryAnalysisPlatform/bap-container.git
-
-  cd bap-container
-  mkdir build && cd build
-  cmake -DCMAKE_CXX_COMPILER=g++-4.8 ..
-  make
-fi
-
-# installed at bap/bap-lifter/toil.native
-
+opam install $OPAM_DEPENDS
+eval `opam config env`
+oasis setup
+./configure --prefix=`opam config var prefix` --with-cxx=`which clang++`
+make
+make install
+popd

--- a/install.sh
+++ b/install.sh
@@ -44,8 +44,8 @@ else
   ./capstone_build.sh
 fi
 
-if [ -d "bap" ]; then
-    echo "using existing BAP"
+if [ -d bap -o "x$BAP" = "xdisable" ]; then
+    echo "skipping BAP"
 else
     echo "building BAP"
     ./bap_build.sh

--- a/install.sh
+++ b/install.sh
@@ -35,13 +35,21 @@ fi
 echo "installing pip packages"
 virtualenv venv
 source venv/bin/activate
-$PIP install --upgrade -r requirements.txt 
+$PIP install --upgrade -r requirements.txt
 
 # build capstone if we don't have it
 if [ $(python -c "import capstone; exit(69 if (capstone.cs_version() == capstone.version_bind() and capstone.cs_version()[0] == 3) else 0)"; echo $?) == 69 ]; then
   echo "capstone already installed, skipping"
 else
   ./capstone_build.sh
+fi
+
+if [ -d "bap" ]; then
+    echo "using existing BAP"
+else
+    echo "building BAP"
+    ./bap_build.sh
+    $PIP install ./bap/python
 fi
 
 echo "making symlink"
@@ -52,5 +60,4 @@ echo "  Thanks for installing QIRA"
 echo "  Check out README for more info"
 echo "  Or just dive in with 'qira /bin/ls'"
 echo "  And point Chrome to localhost:3002"
-echo "    ~geohot" 
-
+echo "    ~geohot"

--- a/middleware/qira_config.py
+++ b/middleware/qira_config.py
@@ -16,10 +16,10 @@ sys.path.append(BASEDIR)
 
 # capstone is now a requirement
 WITH_CAPSTONE = True
+WITH_BAP = True
 
 # turn this off for now on releases
 WITH_STATIC = False
 STATIC_ENGINE = "builtin"
 
 WEBSOCKET_DEBUG = False
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,3 @@ capstone==3.0
 hexdump
 nose
 ./qiradb
-../bap/python

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ capstone==3.0
 hexdump
 nose
 ./qiradb
+../bap/python

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -9,6 +9,7 @@ if [ "$1" == "distrib" ] ; then
   cd ../../
 fi
 
+eval `opam config env`
 bap-server &
 
 source venv/bin/activate

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -10,8 +10,6 @@ if [ "$1" == "distrib" ] ; then
 fi
 
 eval `opam config env`
-bap-server &
-
 source venv/bin/activate
 nosetests
 
@@ -24,5 +22,4 @@ sleep 2
 # phantomjs
 phantomjs qira_tests/load_page.js
 
-killall bap-server
 kill $QIRA_PID

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -9,6 +9,8 @@ if [ "$1" == "distrib" ] ; then
   cd ../../
 fi
 
+bap-server &
+
 source venv/bin/activate
 nosetests
 
@@ -21,5 +23,5 @@ sleep 2
 # phantomjs
 phantomjs qira_tests/load_page.js
 
+killall bap-server
 kill $QIRA_PID
-

--- a/static2/builtin/analyzer.py
+++ b/static2/builtin/analyzer.py
@@ -15,9 +15,6 @@ def analyze_functions(static):
 # runs the recursive descent parser at address
 # how to deal with block groupings?
 def make_function_at(static, address, recurse = True):
-  if static['arch'] != "i386" and static['arch'] != "x86-64":
-    print "*** static only works with x86(_64), someone should fix it"
-    return
   if static[address]['function'] != None:
     # already function
     return
@@ -86,4 +83,3 @@ def make_function_at(static, address, recurse = True):
   for f in function_starts:
     if static[f]['function'] == None:
       make_function_at(static, f)
-

--- a/static2/model.py
+++ b/static2/model.py
@@ -4,7 +4,7 @@ import capstone # for some unexported (yet) symbols in Capstone 3.0
 try:
   import bap
   from bap import adt, arm, asm, bil
-  from adt import Visitor, visit
+  from bap.adt import Visitor, visit
 except ImportError:
   pass
 


### PR DESCRIPTION
This is preliminary PR, consider it just as a place for discussion. 

I've implemented `BapInsn` class that has the same interface as `Instruction`. It uses bil if possible, otherwise falls back to disassembly and LLVM classifications.  `BapInsn` is used whenever is possible with a fallback to `CsInsn` (the new name of  `Instruction` class).

I've also removed guard from `analyzer.make_function_at` to see if it will cope with `ARM`.

In order to run `qira` with bap, right now the following steps must be done:

1. install `bap-server`, either using precompiled binary, or compile it yourself, from here
    https://github.com/ivg/bap/releases/tag/0.1-bap%2Bqira

2. run it, no parameters are expected
    (currently I've disabled autospawning in bap+qira, due to qira's aggressive threading policy, but I hope to reintroduce it back)

3. install bap python bindings, with `pip install <path-to-bap>/python`
    Currently I've hardcoded it into `dependency.txt`



    
     
