### PR TITLE
Static Tester Updates

### DIFF
--- a/static2/builtin/loader.py
+++ b/static2/builtin/loader.py
@@ -36,6 +36,8 @@ def load_binary(static):
 
     if isinstance(section, RelocationSection):
       symtable = elf.get_section(section['sh_link'])
+      if symtable.is_null():
+        continue
       for rel in section.iter_relocations():
         symbol = symtable.get_symbol(rel['r_info_sym'])
         if static.debug >= 1: #suppress output for testing

--- a/static2/testing.py
+++ b/static2/testing.py
@@ -84,14 +84,15 @@ def test_files(fns,quiet=False,profile=False):
         if len(missed) == 0:
           print "{} {}: {} engine found all {} function(s).".format(ok_green, short_fn, engine, total_fxns)
         else:
+          status = fail if len(missed) == total_fxns else warn
           if args.verbose:
             fmt = "{} {}: {} engine missed {}/{} function(s): {}."
             missed_s = ", ".join(hex(fxn) for fxn in missed)
-            print fmt.format(warn, short_fn, engine,
+            print fmt.format(status, short_fn, engine,
                     len(missed), total_fxns, missed_s)
           else:
             fmt = "{} {}: {} engine missed {}/{} function(s)."
-            print fmt.format(warn, short_fn, engine,
+            print fmt.format(status, short_fn, engine,
                     len(missed), total_fxns)
     else:
       for engine,functions in engine_functions.iteritems():

--- a/static2/testing.py
+++ b/static2/testing.py
@@ -75,7 +75,8 @@ def test_files(fns,quiet=False,profile=False):
         print "User stopped processing test cases."
         sys.exit()
       except:
-        print "{} {}: {} engine failed to process file".format(fail, short_fn, engine)
+        print "{} {}: {} engine failed to process file".format(fail, short_fn,
+                                                               engine)
         continue
 
     if elf.has_dwarf_info():
@@ -85,7 +86,10 @@ def test_files(fns,quiet=False,profile=False):
         missed = dwarf_functions - functions
         total_fxns = len(dwarf_functions)
         if len(missed) == 0:
-          print "{} {}: {} engine found all {} function(s)".format(ok_green, short_fn, engine, total_fxns)
+          print "{} {}: {} engine found all {} function(s)".format(ok_green,
+                                                                   short_fn,
+                                                                   engine,
+                                                                   total_fxns)
         else:
           status = fail if len(missed) == total_fxns else warn
           if args.verbose:

--- a/static2/testing.py
+++ b/static2/testing.py
@@ -71,6 +71,9 @@ def test_files(fns,quiet=False,profile=False):
         else:
           this_engine.process()
         engine_functions[engine] = {x.start for x in this_engine['functions']}
+      except KeyboardInterrupt:
+        print "User stopped processing test cases."
+        sys.exit()
       except:
         print "{} {}: {} engine failed to process file".format(fail, short_fn, engine)
         continue

--- a/static2/testing.py
+++ b/static2/testing.py
@@ -82,16 +82,16 @@ def test_files(fns,quiet=False,profile=False):
         missed = dwarf_functions - functions
         total_fxns = len(dwarf_functions)
         if len(missed) == 0:
-          print "{} {}: {} engine found all {} function(s).".format(ok_green, short_fn, engine, total_fxns)
+          print "{} {}: {} engine found all {} function(s)".format(ok_green, short_fn, engine, total_fxns)
         else:
           status = fail if len(missed) == total_fxns else warn
           if args.verbose:
-            fmt = "{} {}: {} engine missed {}/{} function(s): {}."
+            fmt = "{} {}: {} engine missed {}/{} function(s): {}"
             missed_s = ", ".join(hex(fxn) for fxn in missed)
             print fmt.format(status, short_fn, engine,
                     len(missed), total_fxns, missed_s)
           else:
-            fmt = "{} {}: {} engine missed {}/{} function(s)."
+            fmt = "{} {}: {} engine missed {}/{} function(s)"
             print fmt.format(status, short_fn, engine,
                     len(missed), total_fxns)
     else:
@@ -103,7 +103,7 @@ def test_files(fns,quiet=False,profile=False):
 if __name__ == "__main__":
   #todo: radare and summary screen comparing total performance by engine/arch
   parser = argparse.ArgumentParser(description="Test performance of static"
-    "engines, requires dwarf test cases.")
+    "engines, takes advantage of DWARF information if present.")
   parser.add_argument("files", metavar="file", nargs="*",
                       help="use user-specified binaries")
   parser.add_argument("--quiet",dest="quiet",action="store_true",

--- a/static2/testing.py
+++ b/static2/testing.py
@@ -138,7 +138,7 @@ if __name__ == "__main__":
   else:
     if args.profile:
       print "Profiling over entire test suite. Are you sure that's what you wanted?"
-    fns = get_file_list(TEST_PATH, args.recursive)
+    fns = get_file_list([TEST_PATH], args.recursive)
     if len(fns) == 0:
       print "No files found in {}. Try running python autogen.py --dwarf in the tests directory.".format(TEST_PATH)
 

--- a/static2/testing.py
+++ b/static2/testing.py
@@ -54,12 +54,6 @@ def test_files(fns,quiet=False,profile=False):
         print "{} Skipping non-ELF file `{}'".format(warn, fn)
       continue
 
-    has_dwarf = True
-    if not elf.has_dwarf_info():
-      if not quiet:
-        print "{} No dwarf info for `{}', only checking runtime errors".format(warn, fn)
-      has_dwarf = False
-
     engine_functions = {}
     for engine in ENGINES:
       this_engine = Static(fn, debug=0, static_engine=engine) #no debug output
@@ -76,7 +70,7 @@ def test_files(fns,quiet=False,profile=False):
       engine_functions[engine] = {x.start for x in this_engine['functions']}
 
     short_fn = fn.split("/")[-1] if "/" in fn else fn
-    if has_dwarf:
+    if elf.has_dwarf_info():
       dwarfinfo = elf.get_dwarf_info()
       dwarf_functions = get_functions(dwarfinfo)
       for engine,functions in engine_functions.iteritems():
@@ -96,7 +90,7 @@ def test_files(fns,quiet=False,profile=False):
                     len(missed), total_fxns)
     else:
       for engine,functions in engine_functions.iteritems():
-        print "{} {}: {} found {} function(s).".format(ok_blue, short_fn, engine, len(functions))
+        print "{} {}: {} found {} function(s). (dwarf info unavailable)".format(ok_blue, short_fn, engine, len(functions))
 
 
 

--- a/static2/testing.py
+++ b/static2/testing.py
@@ -27,7 +27,8 @@ class bcolors(object):
 
 ok_green = bcolors.OKGREEN + "[+]" + bcolors.ENDC
 ok_blue  = bcolors.OKBLUE  + "[+]" + bcolors.ENDC
-warn = bcolors.WARNING     + "[-]" + bcolors.ENDC
+warn     = bcolors.WARNING + "[-]" + bcolors.ENDC
+fail     = bcolors.FAIL    + "[!]" + bcolors.ENDC
 
 def get_functions(dwarfinfo):
   function_starts = set()
@@ -57,7 +58,11 @@ def test_files(fns,quiet=False,profile=False):
 
     engine_functions = {}
     for engine in ENGINES:
-      this_engine = Static(fn, debug=0, static_engine=engine) #no debug output
+      try:
+        this_engine = Static(fn, debug=0, static_engine=engine) #no debug output
+      except:
+        print "{} {}: {} engine failed to process file".format(fail, short_fn, engine)
+        continue
       if args.profile:
         #needs pycallgraph
         from pycallgraph import PyCallGraph
@@ -77,20 +82,20 @@ def test_files(fns,quiet=False,profile=False):
         missed = dwarf_functions - functions
         total_fxns = len(dwarf_functions)
         if len(missed) == 0:
-          print "{} {}: {} found all {} function(s).".format(ok_green, short_fn, engine, total_fxns)
+          print "{} {}: {} engine found all {} function(s).".format(ok_green, short_fn, engine, total_fxns)
         else:
           if args.verbose:
-            fmt = "{} {}: {} missed {}/{} function(s): {}."
+            fmt = "{} {}: {} engine missed {}/{} function(s): {}."
             missed_s = ", ".join(hex(fxn) for fxn in missed)
             print fmt.format(warn, short_fn, engine,
                     len(missed), total_fxns, missed_s)
           else:
-            fmt = "{} {}: {} missed {}/{} function(s)."
+            fmt = "{} {}: {} engine missed {}/{} function(s)."
             print fmt.format(warn, short_fn, engine,
                     len(missed), total_fxns)
     else:
       for engine,functions in engine_functions.iteritems():
-        print "{} {}: {} found {} function(s). (dwarf info unavailable)".format(ok_blue, short_fn, engine, len(functions))
+        print "{} {}: {} engine found {} function(s). (dwarf info unavailable)".format(ok_blue, short_fn, engine, len(functions))
 
 
 

--- a/static2/testing.py
+++ b/static2/testing.py
@@ -96,7 +96,8 @@ def test_files(fns,quiet=False,profile=False):
                     len(missed), total_fxns)
     else:
       for engine,functions in engine_functions.iteritems():
-        print "{} {}: {} engine found {} function(s). (dwarf info unavailable)".format(ok_blue, short_fn, engine, len(functions))
+        status = fail if len(functions) == 0 else ok_blue
+        print "{} {}: {} engine found {} function(s). (dwarf info unavailable)".format(status, short_fn, engine, len(functions))
 
 
 

--- a/static2/testing.py
+++ b/static2/testing.py
@@ -42,16 +42,20 @@ def get_functions(dwarfinfo):
 
 def test_files(fns,quiet=False,profile=False):
   for fn in fns:
+    if os.path.isdir(fn):
+      if not quiet:
+        print "{} Skipping directory `{}'".format(warn, fn)
+      continue
     try:
       elf = ELFFile(open(fn))
     except ELFError:
       if not quiet:
-        print "Skipping non-ELF file:",fn
+        print "{} Skipping non-ELF file `{}'".format(warn, fn)
       continue
 
     if not elf.has_dwarf_info():
       if not quiet:
-        print "No dwarf info for {}.".format(fn)
+        print "{} No dwarf info for `{}'".format(warn, fn)
       continue
 
     dwarfinfo = elf.get_dwarf_info()
@@ -97,7 +101,7 @@ if __name__ == "__main__":
   parser.add_argument("files", metavar="file", nargs="*",
                       help="use user-specified binaries")
   parser.add_argument("--quiet",dest="quiet",action="store_true",
-                      help="don't warn about missing dwarf information")
+                      help="don't warn about skipped cases")
   parser.add_argument('--profile',dest="profile",action='store_true',
                       help='use internal profiling, output to prof.png')
   parser.add_argument('--verbose',dest="verbose",action="store_true",

--- a/static2/testing.py
+++ b/static2/testing.py
@@ -60,20 +60,20 @@ def test_files(fns,quiet=False,profile=False):
     for engine in ENGINES:
       try:
         this_engine = Static(fn, debug=0, static_engine=engine) #no debug output
+        if args.profile:
+          #needs pycallgraph
+          from pycallgraph import PyCallGraph
+          from pycallgraph.output import GraphvizOutput
+          graphviz = GraphvizOutput()
+          graphviz.output_file = 'prof.png'
+          with PyCallGraph(output=graphviz):
+            this_engine.process()
+        else:
+          this_engine.process()
+        engine_functions[engine] = {x.start for x in this_engine['functions']}
       except:
         print "{} {}: {} engine failed to process file".format(fail, short_fn, engine)
         continue
-      if args.profile:
-        #needs pycallgraph
-        from pycallgraph import PyCallGraph
-        from pycallgraph.output import GraphvizOutput
-        graphviz = GraphvizOutput()
-        graphviz.output_file = 'prof.png'
-        with PyCallGraph(output=graphviz):
-          this_engine.process()
-      else:
-        this_engine.process()
-      engine_functions[engine] = {x.start for x in this_engine['functions']}
 
     if elf.has_dwarf_info():
       dwarfinfo = elf.get_dwarf_info()

--- a/static2/testing.py
+++ b/static2/testing.py
@@ -103,21 +103,20 @@ def test_files(fns,quiet=False,profile=False):
         print "{} {}: {} engine found {} function(s). (dwarf info unavailable)".format(status, short_fn, engine, len(functions))
 
 def get_file_list(location, recursive=False):
-  if not recursive:
-    fns = []
+  fns = []
+  if recursive:
+    for loc in location:
+      for fn in glob(loc):
+        if os.path.isdir(fn):
+          for root, dirnames, filenames in os.walk(fn):
+            fns += [os.path.join(root, f) for f in filenames]
+        else:
+          fns.append(fn)
+  else:
     for loc in location:
       for fn in glob(loc):
         if not os.path.isdir(fn):
           fns.append(fn)
-    return fns
-  fns = []
-  for loc in location:
-    for fn in glob(loc):
-      if os.path.isdir(fn):
-        for root, dirnames, filenames in os.walk(fn):
-          fns += [os.path.join(root, f) for f in filenames]
-      else:
-        fns.append(fn)
   return fns
 
 if __name__ == "__main__":

--- a/static2/testing.py
+++ b/static2/testing.py
@@ -43,15 +43,16 @@ def get_functions(dwarfinfo):
 
 def test_files(fns,quiet=False,profile=False):
   for fn in fns:
+    short_fn = fn.split("/")[-1] if "/" in fn else fn
     if os.path.isdir(fn):
       if not quiet:
-        print "{} Skipping directory `{}'".format(warn, fn)
+        print "{} {}: skipping directory".format(warn, short_fn)
       continue
     try:
       elf = ELFFile(open(fn))
     except ELFError:
       if not quiet:
-        print "{} Skipping non-ELF file `{}'".format(warn, fn)
+        print "{} {}: skipping non-ELF file".format(warn, short_fn)
       continue
 
     engine_functions = {}
@@ -69,7 +70,6 @@ def test_files(fns,quiet=False,profile=False):
         this_engine.process()
       engine_functions[engine] = {x.start for x in this_engine['functions']}
 
-    short_fn = fn.split("/")[-1] if "/" in fn else fn
     if elf.has_dwarf_info():
       dwarfinfo = elf.get_dwarf_info()
       dwarf_functions = get_functions(dwarfinfo)

--- a/tests_new/autogen.py
+++ b/tests_new/autogen.py
@@ -34,9 +34,10 @@ class arch(object):
   x86     = 0
   x86_64  = 1
   arm     = 2
-  aarch64 = 3
-  ppc     = 4
-  ppc64   = 5
+  thumb   = 3
+  aarch64 = 4
+  ppc     = 5
+  ppc64   = 6
 
 def compiler_command(path,filename,this_arch,args):
   command = []
@@ -59,8 +60,11 @@ def compiler_command(path,filename,this_arch,args):
     command += [compiler,"-m64"]
     raw_filename += "_x86-64"
   elif this_arch == arch.arm:
-    command += [ARM_GCC]
+    command += [ARM_GCC, "-marm"]
     raw_filename += "_arm"
+  elif this_arch == arch.thumb:
+    command += [ARM_GCC, "-mthumb"]
+    raw_filename += "_thumb"
   elif this_arch == arch.aarch64:
     command += [AARCH64_GCC]
     raw_filename += "_aarch64"
@@ -103,6 +107,8 @@ def argument_parse():
                       help="generate x86_64 binaries")
   parser.add_argument("--arm",dest="arm",action="store_true",
                       help="generate arm binaries")
+  parser.add_argument("--thumb",dest="thumb",action="store_true",
+                      help="generate thumb binaries")
   parser.add_argument("--aarch64",dest="aarch64",action="store_true",
                       help="generate aarch64 binaries")
   parser.add_argument("--ppc",dest="ppc",action="store_true",
@@ -127,7 +133,7 @@ def argument_parse():
 def get_archs(args):
   archs = []
   if args.all_archs and not args.clang:
-    archs = [arch.x86,arch.x86_64,arch.arm,arch.aarch64,arch.ppc,arch.ppc64]
+    archs = [arch.x86,arch.x86_64,arch.arm,arch.thumb,arch.aarch64,arch.ppc,arch.ppc64]
   else:
     if args.x86:
       archs.append(arch.x86)
@@ -135,6 +141,8 @@ def get_archs(args):
       archs.append(arch.x86_64)
     if args.arm:
       archs.append(arch.arm)
+    if args.thumb:
+      archs.append(arch.thumb)
     if args.aarch64:
       archs.append(arch.aarch64)
     if args.ppc:


### PR DESCRIPTION
I've made some improvements to the static tester/compiler driver:

Added distinction between ARM and THUMB compilation in autogen.py
Better handling of DWARF not produced by us (BinaryAnalysisPlatform/x86-binaries,arm-binaries,etc.)
Various visual improvements/refactoring
Don't skip files without DWARF info, just inform the user (in case you want to run on CTF binaries, etc.)

The last addition revealed a runtime error in the builtin loader when the symbol table was null. I ran it over the existing tests/ directory and it seemed to crash on argtest_static.