### PR TITLE
Specify llvm_version to bap installation.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,7 @@ else
     sudo apt-get install libgmp-dev llvm-3.4-dev time
 
     opam init
-    opam install bap
+    llvm_version=3.4 opam install bap
 
     $PIP install --upgrade git+git://github.com/BinaryAnalysisPlatform/bap.git
 fi


### PR DESCRIPTION
We are specifically installing llvm-3.4, so we can supply this information to the bap installation.