### PR TITLE
Fixes to CFG on x86, x86-64, and ARM

### DIFF
--- a/static2/builtin/analyzer.py
+++ b/static2/builtin/analyzer.py
@@ -43,7 +43,7 @@ def make_function_at(static, address, recurse = True):
 
       #if we come after a jump and are an implicit xref, we are the start
       #of a new block
-      elif d.is_jump():
+      elif d.is_jump() and not d.is_call():
         static._auto_update_name(c,"loc_%x"%(c))
         block_starts.add(c)
     return d.dests()

--- a/static2/model.py
+++ b/static2/model.py
@@ -115,7 +115,7 @@ class BapInsn(object):
       return not self.is_conditional()
 
   def code_follows(self):
-    return not (self.is_ret() or self.is_unconditional())
+    return self.is_call() or not (self.is_ret() or self.is_unconditional())
 
   def size(self):
     return self.insn.size

--- a/static2/model.py
+++ b/static2/model.py
@@ -72,8 +72,8 @@ class BapInsn(object):
       #we want to check here if this is a relative or absolute jump
       #once we have BIL on x86 and x86-64 this won't matter
       if isinstance(dst, asm.Imm):
-        dst_tmp = address + calc_offset(dst.arg, arch)
-        if arch in ["x86","x86-64"]: #jump after instruction on x86, bap should tell us this
+        dst_tmp = calc_offset(dst.arg, arch)
+        if arch in ["i386","x86-64"]: #jump after instruction on x86, bap should tell us this
           dst_tmp += self.insn.size
         dests.append((dst_tmp + address, self.dtype))
 

--- a/static2/model.py
+++ b/static2/model.py
@@ -91,6 +91,9 @@ class BapInsn(object):
     else:
       return len(self.jumps) != 0
 
+  def is_hlt(self):
+    return self.insn.asm == "\thlt" #x86 specific. BAP should be identifying this as an ending
+
   def is_ret(self):
     return self.insn.has_kind(asm.Return)
 
@@ -98,10 +101,14 @@ class BapInsn(object):
     return self.insn.has_kind(asm.Call)
 
   def is_ending(self):
+    if self.is_hlt() or self.is_ret():
+      return True
+
     if self.insn.bil is None:
       return self.insn.has_kind(asm.Terminator)
     else:
-      return self.is_jump() and self.is_unconditional() and not self.is_call()
+      return self.insn.has_kind(asm.Terminator) or \
+            (self.is_jump() and not self.is_call())
 
   def is_conditional(self):
     if self.insn.bil is None:

--- a/static2/model.py
+++ b/static2/model.py
@@ -188,9 +188,7 @@ if qira_config.WITH_BAP:
       else:
         offset_fixed = offset
     else:
-      #this is bad; we seem to get 64bit offsets sometimes from bap
-      #use an assert here to catch errors instead
-      offset = offset & 0xFFFFFFFF
+      assert offset == offset & 0xFFFFFFFF #it's actually 32 bits
       if (offset >> 31) & 1 == 1:
         offset_fixed = -(0xFFFFFFFF-offset+1)
       else:

--- a/static2/model.py
+++ b/static2/model.py
@@ -95,7 +95,7 @@ class BapInsn(object):
     if self.insn.bil is None:
       return self.insn.has_kind(asm.Terminator)
     else:
-      return self.is_jump and self.is_unconditional()
+      return self.is_jump() and self.is_unconditional() and not self.is_call()
 
   def is_conditional(self):
     if self.insn.bil is None:


### PR DESCRIPTION
Bap introduced errors in the CFG recovery on x86 and x86-64. This fixes those. 
Additionally, we are now using BIL to assist in CFG recovery when it is available (only ARM right now).