### PR TITLE
Make static non-blocking, support runtime error checks in tester

### DIFF
--- a/middleware/qira_program.py
+++ b/middleware/qira_program.py
@@ -53,12 +53,12 @@ class Program:
     print "*** program is",self.program,"with hash",self.proghash
 
     # this is always initted, as it's the tag repo
-    self.static = static2.Static(self.program) 
+    self.static = static2.Static(self.program)
 
     # init static
     if qira_config.WITH_STATIC:
-      self.static.process()
-    
+      threading.Thread(target=self.static.process).start()
+
     # no traces yet
     self.traces = {}
     self.runnable = False
@@ -231,7 +231,7 @@ class Program:
     # delete the logs
     shutil.rmtree(qira_config.TRACE_FILE_BASE)
     os.mkdir(qira_config.TRACE_FILE_BASE)
-  
+
   def get_maxclnum(self):
     ret = {}
     for t in self.traces:
@@ -271,7 +271,7 @@ class Program:
       eargs = [self.qirabinary]+self.defaultargs+args+[self.program]+self.args
     #print "***",' '.join(eargs)
     os.execvp(eargs[0], eargs)
-  
+
 
 class Trace:
   def __init__(self, fn, forknum, program, r1, r2, r3):
@@ -296,7 +296,7 @@ class Trace:
 
   def fetch_raw_memory(self, clnum, address, ln):
     return ''.join(map(chr, self.fetch_memory(clnum, address, ln).values()))
-    
+
   # proxy the db call and fill in base memory
   def fetch_memory(self, clnum, address, ln):
     mem = self.db.fetch_memory(clnum, address, ln)
@@ -404,7 +404,7 @@ class Trace:
         return get_forkbase_from_log(ret)
 
     try:
-      forkbase = get_forkbase_from_log(self.forknum) 
+      forkbase = get_forkbase_from_log(self.forknum)
       print "*** using base %d for %d" % (forkbase, self.forknum)
       f = open(qira_config.TRACE_FILE_BASE+str(forkbase)+"_base")
     except Exception, e:

--- a/middleware/qira_webserver.py
+++ b/middleware/qira_webserver.py
@@ -274,11 +274,12 @@ def getinstructions(forknum, clnum, clstart, clend):
       raw = trace.fetch_raw_memory(i, rret['address'], rret['data'])
       rret['instruction'] = str(model.Instruction(raw, rret['address'], arch))
 
-
-    if instr.is_call():
-      args = qira_analysis.display_call_args(instr,trace,i)
-      if args != "":
-        rret['instruction'] += " {"+args+"}"
+    #display_call_args calls make_function_at
+    if qira_config.WITH_STATIC:
+      if instr.is_call():
+        args = qira_analysis.display_call_args(instr,trace,i)
+        if args != "":
+          rret['instruction'] += " {"+args+"}"
 
     if 'name' in program.static[rret['address']]:
       #print "setting name"

--- a/middleware/qira_webserver.py
+++ b/middleware/qira_webserver.py
@@ -167,7 +167,7 @@ def analysis(forknum):
   data = qira_analysis.get_vtimeline_picture(trace)
   if data != None:
     emit('setpicture', {"forknum":forknum, "data":data})
-  
+
 @socketio.on('connect', namespace='/qira')
 @socket_method
 def connect():
@@ -313,7 +313,7 @@ def getinstructions(forknum, clnum, clstart, clend):
     clcurr -= 1
 
   clcurr = clnum
-  while len(ret) != (clend - clnum) and clcurr <= trace.maxclnum:
+  while len(ret) != (clend - clnum) and clcurr <= clend:
     rret = get_instruction(clcurr)
     if rret != None:
       ret.append(rret)
@@ -370,7 +370,7 @@ def getregisters(forknum, clnum):
     if REGS[i] == None:
       continue
     rret = {"name": REGS[i], "address": i*REGSIZE, "value": ghex(regs[i]), "size": REGSIZE, "regactions": ""}
-      
+
     act = set()
     for c in cls:
       if c['address'] == i*REGSIZE:
@@ -391,7 +391,7 @@ def getregisters(forknum, clnum):
   emit('registers', ret)
 
 # ***** generic webserver stuff *****
-  
+
 @app.route('/', defaults={'path': 'index.html'})
 @app.route('/<path:path>')
 def serve(path):

--- a/static2/builtin/analyzer.py
+++ b/static2/builtin/analyzer.py
@@ -80,6 +80,7 @@ def make_function_at(static, address, recurse = True):
     static['blocks'].add(this_block)
 
    # find more functions
-  for f in function_starts:
-    if static[f]['function'] == None:
-      make_function_at(static, f)
+  if recurse:
+    for f in function_starts:
+      if static[f]['function'] == None:
+        make_function_at(static, f)

--- a/static2/builtin/analyzer.py
+++ b/static2/builtin/analyzer.py
@@ -1,6 +1,7 @@
 import Queue
 from model import Function, Block, DESTTYPE
 import byteweight
+import time
 
 def analyze_functions(static):
   make_function_at(static, static['entry'])
@@ -18,6 +19,7 @@ def make_function_at(static, address, recurse = True):
   if static[address]['function'] != None:
     # already function
     return
+  start = time.time()
   block_starts = set([address])
   function_starts = set()
   this_function = Function(address)
@@ -61,6 +63,9 @@ def make_function_at(static, address, recurse = True):
       if d not in done:
         pending.put(d)
         done.add(d)
+    if (time.time() - start) > 0.01:
+      time.sleep(0.01)
+      start = time.time()
 
   #print map(hex, done)
 
@@ -77,6 +82,9 @@ def make_function_at(static, address, recurse = True):
       i = static[address]['instruction']
       this_block.add(address)
       static[address]['block'] = this_block
+      if (time.time() - start) > 0.01:
+        time.sleep(0.01)
+        start = time.time()
     static['blocks'].add(this_block)
 
    # find more functions

--- a/static2/testing.py
+++ b/static2/testing.py
@@ -31,6 +31,7 @@ class bcolors(object):
 
 ok_green = bcolors.OKGREEN + "[+]" + bcolors.ENDC
 ok_blue  = bcolors.OKBLUE  + "[+]" + bcolors.ENDC
+notice   = bcolors.OKBLUE  + "[*]" + bcolors.ENDC
 warn     = bcolors.WARNING + "[-]" + bcolors.ENDC
 fail     = bcolors.FAIL    + "[!]" + bcolors.ENDC
 
@@ -51,13 +52,13 @@ def test_files(fns,quiet=False,profile=False,runtime=False):
     short_fn = fn.split("/")[-1] if "/" in fn else fn
     if os.path.isdir(fn):
       if not quiet:
-        print "{} {}: skipping directory".format(warn, short_fn)
+        print "{} {}: skipping directory".format(notice, short_fn)
       continue
     try:
       elf = ELFFile(open(fn))
     except ELFError:
       if not quiet:
-        print "{} {}: skipping non-ELF file".format(warn, short_fn)
+        print "{} {}: skipping non-ELF file".format(notice, short_fn)
       continue
 
     engine_functions = {}
@@ -76,7 +77,7 @@ def test_files(fns,quiet=False,profile=False,runtime=False):
           this_engine.process()
         engine_functions[engine] = {x.start for x in this_engine['functions']}
       except KeyboardInterrupt:
-        print "User stopped processing test cases."
+        print "{} User stopped processing test cases.".format(notice)
         sys.exit()
       except MemoryError:
         #print "{} {}: bap encountered a memory error.".format(fail, short_fn, engine)


### PR DESCRIPTION
Before, QIRA would not respond until it finished the static analysis. For large programs, this could take minutes, which was unacceptable. In this pull request, I address this problem by running the analysis in a thread, just like the dynamic analysis is currently done. I've also fixed a bug in which the instruction view and the static view (when enabled) would fail to display properly when the dynamic analysis took a long time to complete, never setting trace.maxclnum.

In summary, these changes allow a user to jump right into the trace, with the static view on the right updating to display functions as they are identified. Before making these changes, I checked bap-objdump and IDA against QIRA's static performance. It was apparent to me that these tools can take a significant amount of time to finish autoanalysis as well, but with IDA the user interface is immediately available and so the user experience is vastly improved. We're much more IDA-like now in this regard.

We now also support checking for runtime errors in the static tester. This will soon be integrated into Travis.