### PR TITLE
Travis Static Runtime-Error Checking

### DIFF
--- a/qira_tests/test_static2.py
+++ b/qira_tests/test_static2.py
@@ -1,8 +1,9 @@
 import sys
 sys.path.append("static2/")
+sys.path.append("middleware/")
 import static2
+import testing
 
 def test():
-  static = static2.Static('qira_tests/bin/loop', debug=1)
-  static.process()
-
+  fns = testing.get_file_list([testing.TEST_PATH], recursive=True)
+  testing.test_files(fns, quiet=True, profile=False, runtime=True)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -9,6 +9,11 @@ if [ "$1" == "distrib" ] ; then
   cd ../../
 fi
 
+# generate test cases
+cd tests_auto
+./autogen.py --dwarf
+cd ..
+
 eval `opam config env`
 source venv/bin/activate
 nosetests

--- a/static2/testing.py
+++ b/static2/testing.py
@@ -65,7 +65,7 @@ def test_files(fns,quiet=False,profile=False,runtime=False):
     for engine in ENGINES:
       try:
         this_engine = Static(fn, debug=0, static_engine=engine) #no debug output
-        if args.profile:
+        if profile:
           #needs pycallgraph
           from pycallgraph import PyCallGraph
           from pycallgraph.output import GraphvizOutput


### PR DESCRIPTION
This checks static over the binaries in tests_auto, compiled at test
time, making sure we don't get any unexpected runtime exceptions. Right
now it's just doing x86-64 but this is something we could easily tweak to
cover more architectures.