### PR TITLE
Fixes bug with memory regions mapped by mmap2()

### DIFF
--- a/middleware/qira_program.py
+++ b/middleware/qira_program.py
@@ -355,6 +355,11 @@ class Trace:
               except:
                 f = open(files[fil])
               alldat = f.read()
+
+              if fxn == "mmap2":
+                off = 4096*off # offset argument is in terms of pages for mmap2()
+                # is it safe to assume 4096 byte pages?
+
               st = "*** mapping %s %s sz:0x%x off:0x%x @ 0x%X" % (sha1(alldat).hexdigest(), files[fil], sz, off, return_code)
               print st,
               dat = alldat[off:off+sz]


### PR DESCRIPTION
http://man.he.net/man2/mmap2
"The  mmap2()  system  call operates in exactly the same way as mmap(2), except that the final argument specifies the offset into  the  file  in 4096-byte  units  (instead  of  bytes,  as  is  done by mmap(2))."