### PR TITLE
Fix bap-server 'No such file or directory' startup error

### DIFF
--- a/qira
+++ b/qira
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 DIR=$(dirname $(readlink -f $0))
 source $DIR/venv/bin/activate
+eval $(opam config env)
 exec python $DIR/middleware/qira.py $*
 


### PR DESCRIPTION
Currently, `bap.disasm()` tries to start `'bap-server'` which is not in `$PATH` (see `spawn_server()` in `python/bap.py`), but it is installed in `~/.opam/system/bin/bap-server`, failing with:

    bap failed OSError [Errno 2] No such file or directory