### PR TITLE
Fix thumb bug on UI

### DIFF
--- a/middleware/qira_program.py
+++ b/middleware/qira_program.py
@@ -384,6 +384,7 @@ class Trace:
         self.analysisready = False
         minclnum = self.db.get_minclnum()
         maxclnum = self.db.get_maxclnum()
+        self.program.read_asm_file()
         self.flow = qira_analysis.get_instruction_flow(self, self.program, minclnum, maxclnum)
         self.dmap = qira_analysis.get_hacked_depth_map(self.flow, self.program)
         qira_analysis.analyse_calls(self.program, self.flow)

--- a/static2/model.py
+++ b/static2/model.py
@@ -396,7 +396,7 @@ class Tags:
       if tag == "instruction":
         dat = self.static.memory(self.address, 0x10)
         # arch should probably come from the address with fallthrough
-        self.backing['instruction'] = Instruction(dat, self.address, self.static['arch'])
+        self.backing['instruction'] = Instruction(dat, self.address, self.static[self.address]['arch'])
         self.backing['len'] = self.backing['instruction'].size()
         self.backing['type'] = 'instruction'
         return self.backing[tag]


### PR DESCRIPTION
If QIRA doesn't read the asm file soon enough, it doesn't know that some instructions are thumb (according to QEMU). Also, when an instruction is disassembled for the backing store we use the architecture of static, not of the instruction itself. This means that thumb instructions never get disassembled as thumb and so we get garbage on the UI.

This is strictly better than what we had before, but we still have a race condition with static. If static disassembles the instruction before read_asm_file in the dynamic analysis thread we will not have updated the arch to 'thumb' and so the backing store will be wrong. Also, static will generate an invalid CFG. I talked to Tim about this and we agree that it's time we consider recovering the thumb bit ourselves in static like IDA does (the QEMU way is ugly anyways).