### PR TITLE
Load from segments, not sections

### DIFF
--- a/static2/builtin/byteweight.py
+++ b/static2/builtin/byteweight.py
@@ -69,8 +69,7 @@ def fsi(static):
     return []
   trie = load(os.path.join(qira_config.BASEDIR,"static2","builtin","bw_x86"))
   functions = set()
-  (addr, lenn) = static['sections'][-3]
-  for (addr, lenn) in static['sections']:
+  for (addr, lenn) in static['segments']:
     strr = static.memory(addr, lenn)
     for i in range(lenn):
       s = score(strr[i:i+sig_len], trie)

--- a/static2/builtin/loader.py
+++ b/static2/builtin/loader.py
@@ -28,15 +28,15 @@ def load_binary(static):
   static['entry'] = elf['e_entry']
 
   ncount = 0
-  for section in elf.iter_sections():
-    addr = section['sh_addr']
-    slen = section['sh_size']
-    if addr != 0 and slen > 0:
-      static.add_memory_chunk(addr, section.data())
+  for segment in elf.iter_segments():
+    addr = segment['p_vaddr']
+    if segment['p_type'] == 'PT_LOAD':
+      memsize = segment['p_memsz']
+      static.add_memory_chunk(addr, segment.data().ljust(memsize, "\x00"))
 
+  for section in elf.iter_sections():
     if static.debug >= 1:
       print "** found section", section.name, type(section)
-
 
     if isinstance(section, RelocationSection):
       symtable = elf.get_section(section['sh_link'])

--- a/static2/static2.py
+++ b/static2/static2.py
@@ -64,7 +64,7 @@ class Static:
     self.global_tags = {}
     self.global_tags['functions'] = set()
     self.global_tags['blocks'] = set()
-    self.global_tags['sections'] = []
+    self.global_tags['segments'] = []
 
     # concept from qira_program
     self.base_memory = {}
@@ -183,16 +183,16 @@ class Static:
     return ''.join(dat)
 
   def add_memory_chunk(self, address, dat):
-    #print "add section",hex(address),len(dat)
+    #print "add segment",hex(address),len(dat)
     # check for dups
     for (laddress, llength) in self.base_memory:
       if address == laddress:
         if self.base_memory[(laddress, llength)] != dat:
-          print "*** WARNING, changing section",hex(laddress),llength
+          print "*** WARNING, changing segment",hex(laddress),llength
         return
-    
-    # sections should have an idea of section permission
-    self['sections'].append((address, len(dat)))
+
+    # segments should have an idea of segment permission
+    self['segments'].append((address, len(dat)))
     self.base_memory[(address, address+len(dat))] = dat
 
   def process(self):


### PR DESCRIPTION
This fixes a bug where uninitialized sections such as .bss were being loaded with incorrect values.