### PR TITLE
Explicitly Use Python2

### DIFF
--- a/extra/scripts/go.sh
+++ b/extra/scripts/go.sh
@@ -34,18 +34,17 @@ ls -l /tmp/qira*
 
 : <<'END'
 echo "*** build the Program database"
-time python db_commit_asm.py $BIN $SRC
+time python2 db_commit_asm.py $BIN $SRC
 #echo "*** filter the Change database"
-#time python db_filter_log.py
+#time python2 db_filter_log.py
 echo "*** build the Change database"
-time python db_commit_log.py
+time python2 db_commit_log.py
 echo "*** build the memory json"
-time python mem_json_extract.py
+time python2 mem_json_extract.py
 echo "*** build the pmaps database"
-time python segment_extract.py
+time python2 segment_extract.py
 END
 
 #python db_commit_blocks.py
 #python memory_server.py
 #python build_multigraph.py
-

--- a/extra/static/remoteobj.py
+++ b/extra/static/remoteobj.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # remoteobj v0.4, best yet!
 # TODO: This will get wrecked by recursive sets/lists/dicts; need a more picklish method.
 # TODO: Dict/sets/lists should get unpacked to wrappers that are local for read-only access,
@@ -364,7 +364,7 @@ if __name__ == "__main__":
     print >> sys.stderr, "In the client python shell, the server's module is available as 'proxy'"
     print >> sys.stderr, "A good demo is `proxy.__builtins__.__import__('ctypes').memset(0,0,1)`"
     exit(64)
-  
+
   hostport = (argv[2], int(argv[3]))
   password = argv[4] if len(argv) > 4 else 'lol, python'
   if argv[1] == 'server':

--- a/pin/strace/gen_tables.py
+++ b/pin/strace/gen_tables.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # modified from https://github.com/nelhage/ministrace by @nelhage
 
@@ -111,4 +111,3 @@ def main(args):
 
 if __name__ == '__main__':
   sys.exit(main(sys.argv[1:]))
-

--- a/pin/strace/osx_gen.py
+++ b/pin/strace/osx_gen.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
+
 from urllib import urlopen
 syscalls_master = urlopen("http://www.opensource.apple.com/source/xnu/xnu-2422.110.17/bsd/kern/syscalls.master?txt").read()
 x = (i.strip().split(None, 3) for i in syscalls_master.splitlines() if i.strip() and i[0] not in '#;')

--- a/qira
+++ b/qira
@@ -2,5 +2,4 @@
 DIR=$(dirname $(readlink -f $0))
 source $DIR/venv/bin/activate
 eval $(opam config env)
-exec python $DIR/middleware/qira.py $*
-
+exec python2 $DIR/middleware/qira.py $*

--- a/static2/r2/r2pipe.py
+++ b/static2/r2/r2pipe.py
@@ -1,4 +1,4 @@
-#/usr/bin/env python
+#/usr/bin/env python2
 
 import re
 import json
@@ -91,4 +91,3 @@ if __name__ == "__main__":
         print "Error with remote http conection"
     else:
         print disas
-


### PR DESCRIPTION
This does add support for more platforms; however, it does allow platforms like Arch, which default to python3, to be ran with less pain.

I confirmed python2 is defined on ubuntu/trusty.