### PR TITLE
Better handle recursion in depth map.

### DIFF
--- a/middleware/qira_analysis.py
+++ b/middleware/qira_analysis.py
@@ -415,6 +415,10 @@ def display_call_args(instr,trace,clnum):
     ret += ["-> " + ghex(endregs[program.tregs[0].index(outp)])]
   return " ".join(ret)
 
+#finds first occurence of a in l from the right
+#assumes a in l
+def rindex(l, a):
+  return len(l) - l[::-1].index(a) - 1
 
 def get_hacked_depth_map(flow, program):
   start = time.time()
@@ -429,7 +433,7 @@ def get_hacked_depth_map(flow, program):
     last_clnum = clnum
 
     if address in return_stack:
-      return_stack = return_stack[0:return_stack.index(address)]
+      return_stack = return_stack[:rindex(return_stack, address)]
     # ugh, so gross
     ret.append(len(return_stack))
 


### PR DESCRIPTION
I'm beginning to look over some analyzer functions in search of bugs. I noticed that get_hacked_depth_map truncates the return stack at the first occurrence of a return address, making an assumption that return addresses are unique. In any case where the same return address is in the call stack multiple times, we drop more return addresses than necessary.

Here, I'm running QIRA on a simple recursive fibonacci. You can see that the returns do not affect the depth, even though we have enough information to display them accurately.
![old](https://cloud.githubusercontent.com/assets/3682087/6883642/4a99aa46-d58d-11e4-84df-e21d8c4100c2.png)

By indexing from the end of the list instead of the front, the depth map is higher quality:
![new](https://cloud.githubusercontent.com/assets/3682087/6883643/4c423700-d58d-11e4-8a4b-a234b1a6bc80.png)