### PR TITLE
Update fetchlibs.sh

### DIFF
--- a/fetchlibs.sh
+++ b/fetchlibs.sh
@@ -45,11 +45,11 @@ mkdir -p libs
 cd libs
 
 LIBS="libc-bin libstdc++6"
-fetcharch armhf precise
+fetcharch armhf trusty
 fetcharch armel precise
-fetcharch powerpc precise
-fetcharch arm64 saucy
-fetcharch i386 precise
+fetcharch powerpc trusty
+fetcharch arm64 trusty
+fetcharch i386 trusty
 
 # mini debootstrap 
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -9,7 +9,6 @@ if [ "$1" == "distrib" ] ; then
   cd ../../
 fi
 
-eval `opam config env`
 source venv/bin/activate
 nosetests
 


### PR DESCRIPTION
Is there a reason we're not using the newer distributions for fetchlibs? The saucy outright fails to install for me on multiple systems. (Ubuntu 14.04)
Also there was a line using opam in run_tests.sh.