### PR TITLE
Dynamic Instruction Resolution (in Capstone) and Bugfixes

### DIFF
--- a/middleware/arch.py
+++ b/middleware/arch.py
@@ -38,7 +38,7 @@ MIPSREGS = (MIPSREGLIST, 4, True, "mips", ["jal\t","jr\t","jal","jr"])
 MIPSELREGS = (MIPSREGLIST, 4, False, "mipsel", ["jal\t","jr\t","jal","jr"])
 
 # this stuff should be moved to static
-ARMREGS = (['R0','R1','R2','R3','R4','R5','R6','R7','R8','R9','R10','R11','R12','SP','LR','PC'], 4, False, "arm")
+ARMREGS = (['R0','R1','R2','R3','R4','R5','R6','R7','R8','R9','R10','R11','IP','SP','LR','PC'], 4, False, "arm")
 X86REGS = (['EAX', 'ECX', 'EDX', 'EBX', 'ESP', 'EBP', 'ESI', 'EDI', 'EIP'], 4, False, "i386")
 X64REGS = (['RAX', 'RCX', 'RDX', 'RBX', 'RSP', 'RBP', 'RSI', 'RDI', "R8", "R9", "R10", "R11", "R12", "R13", "R14", "R15", 'RIP'], 8, False, "x86-64")
 

--- a/middleware/qira_program.py
+++ b/middleware/qira_program.py
@@ -217,7 +217,8 @@ class Program:
         thumb_flag = d[0]
         if thumb_flag == 't':
           thumb = True
-          # override the arch since it's thumb
+          # override the arch since it's thumb, clear invalid tag
+          del self.static[addr]['instruction']
           self.static[addr]['arch'] = "thumb"
         elif thumb_flag == 'n':
           thumb = False

--- a/middleware/qira_webserver.py
+++ b/middleware/qira_webserver.py
@@ -263,7 +263,7 @@ def getinstructions(forknum, clnum, clstart, clend):
       rret = rret[0]
 
     instr = program.static[rret['address']]['instruction']
-    rret['instruction'] = str(instr)
+    rret['instruction'] = instr.__str__(trace, i) #i == clnum
 
     # check if static fails at this
     if rret['instruction'] == "":

--- a/static2/model.py
+++ b/static2/model.py
@@ -406,8 +406,7 @@ class CsInsn(object):
     Resolves relative reference given trace if possible:
     For example, if the opcode "dword ptr [rax + rax]" is present
     in this instruction and in the given trace and clnum, the
-    value of rax is 2, we resolve this to "dword ptr [0x4]", except
-    in cases where the pointer is not dereferenced (see note 3).
+    value of rax is 2, we resolve this to "dword ptr [0x4]".
 
     Implemented and tested on {x86, x86-64, arm, thumb, aarch64}
 

--- a/static2/model.py
+++ b/static2/model.py
@@ -409,6 +409,8 @@ class CsInsn(object):
     value of rax is 2, we resolve this to "dword ptr [0x4]", except
     in cases where the pointer is not dereferenced (see note 3).
 
+    Implemented and tested on {x86, x86-64, arm, thumb, aarch64}
+
     Design choices / limitations:
     
     1) This is a glorified string parsing hack that assume Intel syntax.
@@ -419,10 +421,11 @@ class CsInsn(object):
     
     2) We don't resolve stack/base pointers. I think the better way to
        handle these are via stack/struct support, with labelled stack elements.
-       On ARM, "fp" isn't in the qiradb so we drop them.
     
-    3) This function should catch all exceptions, returning self.i.op_str
-       by default.
+    3) On ARM, "fp" isn't in the qiradb so we drop them.
+    
+    4) This function must not raise any exceptions, returning self.i.op_str
+       if necessary.
     """
     if trace is None or clnum is None or not self._has_relative_reference():
       return self.i.op_str

--- a/static2/model.py
+++ b/static2/model.py
@@ -83,7 +83,7 @@ class BapInsn(object):
     else:
       self._dests = dests
 
-  def __str__(self):
+  def __str__(self, trace=None, clnum=None):
     # fix relative jumps to absolute address
     for d in self._dests:
       if d[1] is not DESTTYPE.implicit:

--- a/static2/model.py
+++ b/static2/model.py
@@ -511,13 +511,13 @@ class CsInsn(object):
       resolved = resolver(ref)
       return fmt.format(resolved)
     except IgnoredRegister as e:
-      return self.i.op_str
+      pass
     except UnknownRegister as e:
       print "_get_operand_s: unknown register {} at clnum {}".format(e.reg, clnum)
-      return self.i.op_str
     except Exception as e:
       print "unknown exception in _get_operand_s", e
-      return self.i.op_str
+
+    return self.i.op_str
 
   def size(self):
     return self.i.size if self.decoded else 0

--- a/static2/model.py
+++ b/static2/model.py
@@ -415,6 +415,21 @@ class CsInsn(object):
           addr = _eval_op_x86(op1) - _eval_op_x86(op2)
         return addr
 
+      if len(spl) == 5:
+        opr1, op1, opr2, op2, opr3 = spl
+        addr = _eval_op_x86(opr1)
+        if op1 == "+":
+          addr += _eval_op_x86(opr2)
+        else:
+          assert op1 == "-"
+          addr -= _eval_op_x86(opr2)
+        if op2 == "+":
+          addr += _eval_op_x86(opr3)
+        else:
+          assert op2 == "-"
+          addr -= _eval_op_x86(opr3)
+        return addr
+
       if "*" in exp:
         op1, op2 = exp.split("*")
         #assert len(spl2) == 2

--- a/static2/model.py
+++ b/static2/model.py
@@ -480,8 +480,12 @@ class CsInsn(object):
         raise IgnoredRegister(exp)
 
       if exp in reginfo: #it's a register
-        if exp == "pc": #arm is so annoying sometimes
-          return reginfo[exp] + self.size()
+        #http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0552a/BABJJAAA.html
+        if exp == "pc": #arm is *so* annoying sometimes
+          val = reginfo[exp] + 4
+          if val & 2:
+            val -= 2
+          return val
         return reginfo[exp]
 
       #no exception here, ARM is explicit about constants

--- a/static2/model.py
+++ b/static2/model.py
@@ -412,9 +412,9 @@ class CsInsn(object):
 
     Design choices / limitations:
     
-    1) This is a glorified string parsing hack that assume Intel syntax.
+    1) This is a glorified string parsing hack that assumes Intel syntax.
        This is quite ugly IMO, but the alternative is to write our own
-       dissassembler/printer which is unneccessary work. Fortunately,
+       dissassembler/printer which is unnecessary work. Fortunately,
        this is localized to the CsInsn class so we assume that Capstone
        syntax will not change. Otherwise, ping me if this breaks (@nedwill).
     

--- a/static2/model.py
+++ b/static2/model.py
@@ -421,8 +421,6 @@ class CsInsn(object):
     if trace is None or clnum is None or not self._has_relative_reference():
       return self.i.op_str
 
-    print "special case! {} -> {} {}".format(clnum, self.i.mnemonic, self.i.op_str)
-
     reginfo = self._get_register_dict(trace, clnum)
 
     if self.arch in ["i386", "x86-64"]:
@@ -501,12 +499,9 @@ class CsInsn(object):
       resolved = resolver(ref)
       return fmt.format(resolved)
     except IgnoredRegister as e:
-      print "ignored register", e.reg
       return self.i.op_str
     except UnknownRegister as e:
-      print "unknown register", e.reg
-      #if e.reg not in ignored_registers:
-      #  print "unknown register detected in _get_operand_s", e.reg
+      print "_get_operand_s: unknown register {} at clnum {}".format(e.reg, clnum)
       return self.i.op_str
     except Exception as e:
       print "unknown exception in _get_operand_s", e

--- a/static2/model.py
+++ b/static2/model.py
@@ -280,8 +280,11 @@ class CsInsn(object):
         elif self.i.mnemonic[0] == "b" or self.i.mnemonic[:2] == "cb":
           self.dtype = DESTTYPE.cjump
       elif arch == "ppc":
-        if self.i.mnemonic[:2] == "bl" and self.i.mnemonic[3] != "r":
-          self.dtype == DESTTYPE.call
+        if self.i.mnemonic == "bctr":
+          self.dtype = DESTTYPE.none
+        elif self.i.mnemonic[:2] == "bl":
+          if not (len(self.i.mnemonic) > 3 and self.i.mnemonic[3] == "r"):
+            self.dtype = DESTTYPE.call
         elif self.i.mnemonic[:2] == "bc":
           self.dtype = DESTTYPE.cjump
         elif self.i.mnemonic[0] == "b":

--- a/static2/model.py
+++ b/static2/model.py
@@ -280,7 +280,7 @@ class CsInsn(object):
         elif self.i.mnemonic[0] == "b" or self.i.mnemonic[:2] == "cb":
           self.dtype = DESTTYPE.cjump
       elif arch == "ppc":
-        if self.i.mnemonic == "bctr":
+        if self.i.mnemonic in ["bctr", "bctrl"]:
           self.dtype = DESTTYPE.none
         elif self.i.mnemonic[:2] == "bl":
           if not (len(self.i.mnemonic) > 3 and self.i.mnemonic[3] == "r"):

--- a/static2/testing.py
+++ b/static2/testing.py
@@ -95,9 +95,12 @@ def test_files(fns,quiet=False,profile=False,runtime=False):
       except Exception as e:
         print "{} {}: {} engine failed to process file with `{}'".format(fail, short_fn, engine, e)
         continue
+      if runtime:
+        if not quiet:
+          print "{} {}: {} ran without exceptions".format(ok_green, short_fn, engine)
+        continue
+
     if runtime:
-      if not quiet:
-        print "{} {}: {} ran without exceptions".format(ok_green, short_fn, engine)
       continue
 
     if elf.has_dwarf_info():

--- a/static2/testing.py
+++ b/static2/testing.py
@@ -5,6 +5,7 @@ import sys
 import os
 sys.path.insert(0, os.path.join('..','middleware'))
 import qira_config
+import struct
 
 try:
   from static2 import *
@@ -18,9 +19,11 @@ from elftools.elf.elffile import ELFFile
 from elftools.common.exceptions import ELFError, ELFParseError
 from glob import glob
 
+#what capstone supports. if bap comes back we'll have ppc64 too
+SUPPORTED = ["EM_ARM", "EM_X86_64", "EM_AARCH64", "EM_PPC", "EM_386"]
 TEST_PATH = os.path.join(qira_config.BASEDIR,"tests_auto","binary-autogen","*")
-ENGINES = ["builtin", "r2"]
-#ENGINES = ["builtin"]
+#ENGINES = ["builtin", "r2"]
+ENGINES = ["builtin"]
 
 class bcolors(object):
   HEADER = '\033[95m'
@@ -60,6 +63,12 @@ def test_files(fns,quiet=False,profile=False,runtime=False):
     except ELFError:
       if not quiet:
         print "{} {}: skipping non-ELF file".format(notice, short_fn)
+      continue
+
+    arch = elf['e_machine']
+    if arch not in SUPPORTED:
+      if not quiet:
+        print "{} {}: skipping ELF with unsupported architecture `{}`".format(notice, short_fn, arch)
       continue
 
     engine_functions = {}


### PR DESCRIPTION
I've added support for resolving memory references that contain a register if the register's value is available in the QIRAdb.

I've documented the design choices and limitations in the code itself, but I'll copy the relevant bits here:

Now we take optional arguments `(trace, clnum)` on the `__str__` function for an instruction, which will do the dynamic resolution if possible and necessary. This should avoid breaking existing `str(insn)` calls.

This is a glorified string parsing hack that assumes Intel syntax. This is quite ugly IMO, but the alternative is to write our own dissassembler/printer which is unnecessary work. Fortunately, this is localized to the `CsInsn` class so we rely on the fact that Capstone syntax will not change. Otherwise, ping me if this breaks (@nedwill).

We don't resolve stack/base pointers. I think the better way to handle these are via stack/struct support, with named stack labels like in IDA.

This has been handtested on x86, x86-64, arm, thumb, and aarch64. I think all the bugs are squashed at this point.

Other changes made during debugging:
1) Relabel `r12` to `ip` in ARM. `ip` appears in the disassembly but `r12` doesn't seem to (and they are aliases for the same register, of course).
2) Fix race condition in Thumb disassembly on frontend by clearing cache when we learn that an instruction is Thumb.
3) Improve disassembly on PPC: the endianness was wrong and some of the string parsing was broken (raised Exceptions). Those are fixed, but there are still string parsing/coloring bugs on the frontend.
4) Minor fixes to the static tester. I'd like to better incorporate its functionality into the test suite at some point.