### PR TITLE
use SHA256 to verify integrity of binaries grabbed over https.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,8 @@ else
     PIP="pip"
 fi
 
+LIBCAPSTONE_SHA256="a7bf1cb814c6e712a314659b074bc4c00d2e0006cac67d055d3130d4ecdd525d"
+
 unamestr=$(uname)
 if [[ "$unamestr" == 'Linux' ]]; then
   # we need pip to install python stuff
@@ -18,6 +20,15 @@ if [[ "$unamestr" == 'Linux' ]]; then
 
     # install capstone
     curl -o /tmp/libcapstone3.deb http://www.capstone-engine.org/download/3.0.4/ubuntu-14.04/libcapstone3_3.0.4-0.1ubuntu1_amd64.deb
+    HASH=`sha256sum /tmp/libcapstone3.deb 2>/dev/null | cut -d' ' -f1`
+    
+    if [ "$HASH" != "$LIBCAPSTONE_SHA256" ]; then
+
+      echo "Error: libcapstone3.deb has an invalid checksum."
+      exit 1
+
+    fi
+    
     sudo dpkg -i /tmp/libcapstone3.deb
 
     # only python package we install globally

--- a/tracers/qemu_build.sh
+++ b/tracers/qemu_build.sh
@@ -2,6 +2,9 @@
 
 QEMU_VERSION=2.1.3
 
+#hardcoded to 2.1.3 for now
+QEMU_SHA256="9b68fd0e6f6c401939bd1c9c6ab7052d84962007bb02919623474e9269f60a40"
+
 # if you don't have ubuntu you are on your own here
 if [ $(which apt-get) ]; then
   echo "fetching qemu build-deps, enter your password"
@@ -21,6 +24,14 @@ if [ ! -d qemu/qemu-latest ]; then
   mkdir -p qemu
   cd qemu
   wget http://wiki.qemu-project.org/download/qemu-$QEMU_VERSION.tar.bz2
+
+  HASH=`sha256sum ./qemu-"$QEMU_VERSION".tar.bz2 2>/dev/null | cut -d' ' -f1`
+  
+  if [ "$HASH" != "$QEMU_SHA256" ]; then
+    echo "Error: qemu-"$QEMU_VERSION".tar.bz2 has an invalid checksum."
+    exit 1
+  fi
+
   tar xf qemu-$QEMU_VERSION.tar.bz2
   ln -s qemu-$QEMU_VERSION qemu-latest
 


### PR DESCRIPTION
reported by https://twitter.com/flameeyes/status/692491456628527104

Doing this in a pull request so Travis can check it. I'll merge.