### PR TITLE
Proofread README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 * QIRA is a competitor to strace and gdb
 * See http://qira.me/ for high level usage information
 * All QIRA code is released under GPLv2 or BSD
-* Other code in this repo released under it's respective license
+* Other code in this repo released under its respective license
 
 ## Installing release
 
@@ -32,13 +32,13 @@ cd qira/
 
 * v1.1 -- Support for names and comments. Static stuff added. Register colors.
 * v1.0 -- Perf is good! Tons of bugfixes. Quality software. http://qira.me/
-* v0.9 -- Function indentation. haddrline added(look familiar?). Register highlighting in hexdump.
-* v0.8 -- Intel syntax! Shipping CDA(cda a.out) and experimental PIN backend. Bugfixes. Windows support?
+* v0.9 -- Function indentation. haddrline added (look familiar?). Register highlighting in hexdump.
+* v0.8 -- Intel syntax! Shipping CDA (cda a.out) and experimental PIN backend. Bugfixes. Windows support?
 * v0.7 -- DWARF support. Builds QEMU if distributed binaries don't work. Windows IDA plugin.
 * v0.6 -- Added changes before webforking. Highlight strace addresses. Default on analysis.
 * v0.5 -- Fixed regression in C++ database causing wrong values. Added PowerPC support. Added "A" button.
 * v0.4 -- Using 50x faster C++ database. strace support. argv and envp are there.
-* v0.3 -- Built in socat, multiple traces, forks(experimental). Somewhat working x86-64 and ARM support
+* v0.3 -- Built in socat, multiple traces, forks (experimental). Somewhat working x86-64 and ARM support
 * v0.2 -- Removed dependency on mongodb, much faster. IDA plugin fixes, Mac version.
 * v0.1 -- Initial release
 
@@ -47,15 +47,15 @@ cd qira/
 
 <pre>
 At the top, you have 4 boxes, called the controls.
-  Blue = change number, Grey = fork number
-  Red = instruction address(iaddr), Yellow = data address(daddr)
+  Blue = change number, grey = fork number
+  red = instruction address (iaddr), yellow = data address (daddr).
 
 On the left you have the vtimeline, this is the full trace of the program.
   The top is the start of the program, the bottom is the end/current state.
   More green = deeper into a function.
   The currently selected change is blue, red is every passthrough of the current iaddr
   Bright yellow is a write to the daddr, dark yellow is a read from the daddr.
-  This color scheme is followed everywhere
+  This color scheme is followed everywhere.
 
 Below the controls, you have the idump, showing instructions near the current change
 Under that is the regviewer, datachanges, hexeditor, and strace, all self explanatory.
@@ -63,7 +63,7 @@ Under that is the regviewer, datachanges, hexeditor, and strace, all self explan
 
 
 ## Mouse Actions
-Click on vtimeline to navigate around. Right click forks to delete them. Click on data(or doubleclick if highlightable) to follow in data. Right click on instruction address to follow in instruction.
+Click on vtimeline to navigate around. Right-click forks to delete them. Click on data (or doubleclick if highlightable) to follow in data. Right-click on instruction address to follow in instruction.
 
 ## Keyboard Shortcuts in web/client/controls.js
 <pre>
@@ -112,17 +112,17 @@ u -- make undefined at iaddr
 
 ## Session state
 <pre>
-clnum -- Selected changelist number
-forknum -- Selected fork number
-iaddr -- Selected instruction address
-daddr -- Selected data address
+clnum -- selected changelist number
+forknum -- selected fork number
+iaddr -- selected instruction address
+daddr -- selected data address
 
-cview -- Viewed changelists in the vtimeline
-dview -- Viewed window into data in the hexeditor
-iview -- Viewed address in the static view
+cview -- viewed changelists in the vtimeline
+dview -- viewed window into data in the hexeditor
+iview -- viewed address in the static view
 
-max_clnum -- Max changelist number for each fork
-dirtyiaddr -- Whether we should update the clnum based on the iaddr or not
+max_clnum -- max changelist number for each fork
+dirtyiaddr -- whether we should update the clnum based on the iaddr or not
 flat -- if we are in flat view
 </pre>
 


### PR DESCRIPTION
Fix grammar, punctuation, and orthography in README.md.

Note: In English, unlike C code, parentheses are usually preceded by a space.