### PR TITLE
Repo update during pacman dependency installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@ if [[ "$unamestr" == 'Linux' ]]; then
 
   elif [ $(which pacman) ]; then
     echo "installing pip"
-    sudo pacman -S --needed --noconfirm base-devel python2-pip python2-virtualenv
+    sudo pacman -Sy --needed --noconfirm base-devel python2-pip python2-virtualenv
     PIP="pip2"
   elif [ $(which yum) ]; then
     sudo yum install -y python-pip python-devel gcc gcc-c++ python-virtualenv glib2-devel


### PR DESCRIPTION
This eliminates the risk of a dependency not being installed or updated because of
unsynced repo state.

In my setup I did not have virtualenv for python2 and my repos were not synced so it was not installed. It went ahead and created one with python3 and of course qira wouldn't fire up afterwards. Maybe it would be better to have only one check for python2/virtualenv2.