### PR TITLE
Only run readlink on a symlink on OS X

### DIFF
--- a/qira
+++ b/qira
@@ -3,7 +3,11 @@ unamestr=$(uname)
 if [[ "$unamestr" == 'Linux' ]]; then
   DIR=$(dirname $(readlink -f $0))
 elif [[ "$unamestr" == "Darwin" ]]; then
-  DIR=$(dirname $(readlink $(which $0)))
+  cmd=$(which "$0")
+  if [ -L "$cmd" ]; then
+    cmd=$(readlink "$cmd")
+  fi
+  DIR=$(dirname "$cmd")
 else
   echo "Only Linux and Mac OS X are supported!"
   exit


### PR DESCRIPTION
readlink does not print anything if the argument is not actually
a symlink. This change allows running the tool from the current
directory with `./qira`.