### PR TITLE
fix vtimelinebox for chrome 50>=

### DIFF
--- a/web/qira_layout.css
+++ b/web/qira_layout.css
@@ -127,6 +127,7 @@ td {
   white-space: nowrap;
   box-sizing: border-box;
   z-index: 1;
-  position: relative;
+  position: absolute;
+  top: 0;
 }
 


### PR DESCRIPTION
"height: 100%" does not work for child elements of TD tags on chrome 50>=.
This problem can be avoided by specifying "position: absolute".

ref: https://bugs.chromium.org/p/chromium/issues/detail?id=583670&q=label%3ACr-Blink-Layout-Table&colspec=ID%20Pri%20M%20Stars%20ReleaseBlock%20Cr%20Status%20Owner%20Summary%20OS%20Modified