### PR TITLE
Made apt-get options consistent

### DIFF
--- a/tracers/pin_build.sh
+++ b/tracers/pin_build.sh
@@ -12,7 +12,7 @@ Linux)
   # pin build deps, good?
   if which apt-get; then
     echo "apt-getting pin tool building deps"
-    sudo apt-get install gcc-multilib g++-multilib || echo "WARNING: apt-get failed"
+    sudo apt-get -qq -y install gcc-multilib g++-multilib || echo "WARNING: apt-get failed"
   else
     echo "WARNING: you don't have apt-get, you are required to fetch pin tool building deps (e.g. 32 bit libs) on your own"
   fi


### PR DESCRIPTION
apt-get was missing -qq -y options. These two flags are used in the other install scripts and are very convenient.